### PR TITLE
build for 5.11.5 hotfix

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.12.0" %}
+{% set version = "5.11.5" %}
 
 package:
   name: isort
@@ -6,32 +6,31 @@ package:
 
 source:
   url: https://pypi.io/packages/source/i/isort/isort-{{ version }}.tar.gz
-  sha256: 8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504
+  sha256: 6be1f76a507cb2ecf16c7cf14a37e41609ca082330be4e3436a18ef74add55db
 
 build:
-  number: 1
+  number: 0
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
     - isort = isort.main:main
-    - isort-identify-imports = isort.main:identify_imports_main
 
 requirements:
   host:
-    - python >=3.8,<4.0
+    - python >=3.6,<4.0
     - pip
     - poetry-core >=1.0.0
   run:
-    - python >=3.8,<4.0
+    - python >=3.6,<4.0
     - setuptools
 
 test:
   imports:
     - isort
+    - isort._future
   commands:
     - pip check
     - isort --help
-    - isort-identify-imports --help
   requires:
     - pip
 


### PR DESCRIPTION
This picks up the meta.yaml used to build 5.11.4 (https://github.com/conda-forge/isort-feedstock/blob/59a2fba982c37567058ad5044acfe1fb636085d9/recipe/meta.yaml) and adds the version for 5.11.5 (see https://github.com/conda-forge/isort-feedstock/issues/79)

Related to 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
